### PR TITLE
Usage of PHP's own max integer

### DIFF
--- a/src/Commands/SparkCommand.php
+++ b/src/Commands/SparkCommand.php
@@ -28,7 +28,7 @@ class SparkCommand extends Command
 
         // Calculate the inverse.
         $a = new BigInteger($prime);
-        $b = new BigInteger(Optimus::MAX_INT + 1);
+        $b = new BigInteger(PHP_INT_MAX + 1);
 
         if ( ! $inverse = $a->modInverse($b))
         {
@@ -37,7 +37,7 @@ class SparkCommand extends Command
             return;
         }
 
-        $rand = hexdec(bin2hex(Random::string(4))) & Optimus::MAX_INT;
+        $rand = hexdec(bin2hex(Random::string(4))) & PHP_INT_MAX;
 
         $output->writeln('Prime: ' . $prime);
         $output->writeln('Inverse: ' . $inverse);

--- a/src/Optimus.php
+++ b/src/Optimus.php
@@ -7,11 +7,6 @@ class Optimus {
     /**
      * @var integer
      */
-    const MAX_INT = 2147483647;
-
-    /**
-     * @var integer
-     */
     private $prime;
 
     /**
@@ -49,7 +44,7 @@ class Optimus {
             throw new InvalidArgumentException('Argument should be an integer');
         }
 
-        return (((int) $value * $this->prime) & static::MAX_INT) ^ $this->xor;
+        return (((int) $value * $this->prime) & PHP_INT_MAX) ^ $this->xor;
     }
 
     /**
@@ -65,7 +60,7 @@ class Optimus {
             throw new InvalidArgumentException('Argument should be an integer');
         }
 
-        return (((int) $value ^ $this->xor) * $this->inverse) & static::MAX_INT;
+        return (((int) $value ^ $this->xor) * $this->inverse) & PHP_INT_MAX;
     }
 
 }


### PR DESCRIPTION
PHP already has a max integer defined `PHP_INT_MAX` (since PHP 5.0.5), i guess this should be used instead.