### PR TITLE
Extract numbers generation into separate class

### DIFF
--- a/src/Commands/SparkCommand.php
+++ b/src/Commands/SparkCommand.php
@@ -1,8 +1,7 @@
 <?php namespace Jenssegers\Optimus\Commands;
 
-use Jenssegers\Optimus\Optimus;
-use phpseclib\Crypt\Random;
-use phpseclib\Math\BigInteger;
+use Jenssegers\Optimus\Energon;
+use Jenssegers\Optimus\Exceptions\InvalidPrimeException;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
@@ -24,25 +23,12 @@ class SparkCommand extends Command
 
     protected function execute(InputInterface $input, OutputInterface $output)
     {
-        $prime = $input->getArgument('prime');
-
-        // Get a pseudo-random prime.
-        if (! $prime) {
-            $min = new BigInteger(1e7);
-            $max = new BigInteger(Optimus::MAX_INT);
-            $prime = $max->randomPrime($min, $max);
-        }
-
-        // Calculate the inverse.
-        $a = new BigInteger($prime);
-        $b = new BigInteger(Optimus::MAX_INT + 1);
-
-        if (! $inverse = $a->modInverse($b)) {
+        try {
+            list($prime, $inverse, $rand) = Energon::generate($input->getArgument('prime'));
+        } catch (InvalidPrimeException $e) {
             $output->writeln('<error>Invalid prime number</>');
             return;
         }
-
-        $rand = hexdec(bin2hex(Random::string(4))) & Optimus::MAX_INT;
 
         $output->writeln('Prime: ' . $prime);
         $output->writeln('Inverse: ' . $inverse);

--- a/src/Energon.php
+++ b/src/Energon.php
@@ -1,0 +1,121 @@
+<?php namespace Jenssegers\Optimus;
+
+use Jenssegers\Optimus\Exceptions\InvalidPrimeException;
+use phpseclib\Crypt\Random;
+use phpseclib\Math\BigInteger;
+
+class Energon
+{
+    /**
+     * @var \phpseclib\Math\BigInteger
+     */
+    protected $prime;
+
+    /**
+     * Energon constructor.
+     *
+     * @param int|null $prime
+     */
+    public function __construct($prime = null)
+    {
+        if (is_null($prime)) {
+            $prime = static::generatePrime();
+        }
+
+        $this->setPrime($prime);
+    }
+
+    /**
+     * Generates a set of numbers ready for use.
+     *
+     * @param int|null $prime
+     * @return array
+     */
+    public static function generate($prime = null)
+    {
+        $instance = new static($prime);
+
+        return [
+            $instance->getPrime(),
+            $instance->getInverse(),
+            $instance->getRand()
+        ];
+    }
+
+    /**
+     * Generate a random large prime.
+     *
+     * @return int
+     */
+    public static function generatePrime()
+    {
+        $min = new BigInteger(1e7);
+        $max = new BigInteger(Optimus::MAX_INT);
+
+        return (int) $max->randomPrime($min, $max)->toString();
+    }
+
+    /**
+     * Generate a random large number.
+     *
+     * @return int
+     */
+    public static function generateRandomInteger()
+    {
+        return (int) hexdec(bin2hex(Random::string(4))) & Optimus::MAX_INT;
+    }
+
+    /**
+     * Get the current prime.
+     *
+     * @return int
+     */
+    public function getPrime()
+    {
+        return (int) $this->prime->toString();
+    }
+
+    /**
+     * Safely set the current prime as a BigInteger.
+     *
+     * @param mixed $prime
+     */
+    public function setPrime($prime)
+    {
+        if (! $prime instanceof BigInteger) {
+            $prime = new BigInteger($prime);
+        }
+
+        if (! $prime->isPrime()) {
+            throw new InvalidPrimeException($prime);
+        }
+
+        $this->prime = $prime;
+    }
+
+    /**
+     * Get the inverse of the current prime.
+     *
+     * @return int
+     */
+    public function getInverse()
+    {
+        $x = new BigInteger(Optimus::MAX_INT + 1);
+
+        if (! $inverse = $this->prime->modInverse($x)) {
+            throw new InvalidPrimeException($this->prime);
+        }
+
+        return (int) $inverse->toString();
+    }
+
+    /**
+     * Alias method for getting a random big number.
+     *
+     * @return int
+     */
+    public function getRand()
+    {
+        return static::generateRandomInteger();
+    }
+}

--- a/src/Exceptions/InvalidPrimeException.php
+++ b/src/Exceptions/InvalidPrimeException.php
@@ -1,0 +1,24 @@
+<?php namespace Jenssegers\Optimus\Exceptions;
+
+use Exception;
+use phpseclib\Math\BigInteger;
+use RangeException;
+
+class InvalidPrimeException extends RangeException
+{
+    /**
+     * InvalidPrimeException constructor.
+     *
+     * @param string          $message
+     * @param int             $code
+     * @param \Exception|null $previous
+     */
+    public function __construct($message = "", $code = 0, Exception $previous = null)
+    {
+        if ($message instanceof BigInteger) {
+            $message = $message->toString();
+        }
+
+        parent::__construct($message, $code, $previous);
+    }
+}

--- a/tests/EnergonTest.php
+++ b/tests/EnergonTest.php
@@ -1,0 +1,48 @@
+<?php
+
+use Jenssegers\Optimus\Energon;
+use Jenssegers\Optimus\Optimus;
+use phpseclib\Math\BigInteger;
+
+class EnergonTest extends PHPUnit_Framework_TestCase
+{
+    public function testGeneratesRandomSet()
+    {
+        $set = Energon::generate();
+
+        $this->assertCount(3, $set);
+        $this->assertInternalType('integer', $set[0]);
+        $this->assertInternalType('integer', $set[1]);
+        $this->assertInternalType('integer', $set[2]);
+    }
+
+    public function testGeneratesAskedSet()
+    {
+        $set = Energon::generate(1580030173);
+
+        $this->assertCount(3, $set);
+        $this->assertInternalType('integer', $set[0]);
+        $this->assertInternalType('integer', $set[1]);
+        $this->assertInternalType('integer', $set[2]);
+        $this->assertEquals(1580030173, $set[0]);
+        $this->assertEquals(59260789, $set[1]);
+    }
+
+    public function testRandomSetContainsExpectedNumbers()
+    {
+        $set = Energon::generate();
+
+        $first = new BigInteger($set[0]);
+        $x = new BigInteger(Optimus::MAX_INT + 1);
+
+        $this->assertTrue($first->isPrime());
+        $this->assertEquals($first->modInverse($x)->toString(), $set[1]);
+    }
+
+    public function testInvalidPrimeProvided()
+    {
+        $this->setExpectedException('Jenssegers\Optimus\Exceptions\InvalidPrimeException', '2');
+
+        Energon::generate(2);
+    }
+}


### PR DESCRIPTION
As suggested previously in #9 .

Derived packages can as such use a consistent number generation logic instead of needing to define it themselves.

Since this package already includes "Optimus" and its life essence "Spark", I thought "Energon" (Transformer's fuel) would be a great addition :-)

Note that the `optimus` phar still needs to be rebuilt.
