### PR TITLE
Add format option to spark command

### DIFF
--- a/src/Commands/SparkCommand.php
+++ b/src/Commands/SparkCommand.php
@@ -24,6 +24,12 @@ class SparkCommand extends Command
                 InputOption::VALUE_REQUIRED,
                 'The number of bits used to obfuscate the integer. E.g. 16 bits will produce numbers in the range 0 to 65535.',
                 Optimus::DEFAULT_SIZE
+            )->addOption(
+                'format',
+                'f',
+                InputOption::VALUE_OPTIONAL,
+                'The output format. Tip: Use --format=env to directly generate env variables.',
+                'txt'
             )->addArgument(
                 'prime',
                 InputArgument::OPTIONAL,
@@ -57,21 +63,31 @@ class SparkCommand extends Command
             $output->writeln('<error>Invalid prime number</>');
 
             return 1;
-        }
+		}
 
-        $output->writeln('Prime: ' . $prime);
-        $output->writeln('Inverse: ' . $inverse);
-        $output->writeln('Random: ' . $rand);
-        $output->writeln('Bit length: ' . $bitLength);
-        $output->writeln('');
-        $output->writeln(
-            sprintf(
-                '    new Optimus(%s, %s, %s, %s);',
-                $prime,
-                $inverse,
-                $rand,
-                $bitLength
-            )
-        );
+		switch ($input->getOption('format')) {
+			case 'env':
+				$output->writeln('OPTIMUS_PRIME=' . $prime);
+				$output->writeln('OPTIMUS_INVERSE=' . $inverse);
+				$output->writeln('OPTIMUS_RANDOM=' . $rand);
+				$output->writeln('OPTIMUS_BITLENGTH=' . $bitLength);
+				break;
+			default:
+				$output->writeln('Prime: ' . $prime);
+				$output->writeln('Inverse: ' . $inverse);
+				$output->writeln('Random: ' . $rand);
+				$output->writeln('Bit length: ' . $bitLength);
+				$output->writeln('');
+				$output->writeln(
+					sprintf(
+						'    new Optimus(%s, %s, %s, %s);',
+						$prime,
+						$inverse,
+						$rand,
+						$bitLength
+					)
+				);
+				break;
+		}
     }
 }

--- a/src/Commands/SparkCommand.php
+++ b/src/Commands/SparkCommand.php
@@ -63,37 +63,37 @@ class SparkCommand extends Command
             $output->writeln('<error>Invalid prime number</>');
 
             return 1;
-		}
+        }
 
-		switch ($input->getOption('format')) {
-			case 'env':
-				$output->writeln('OPTIMUS_PRIME=' . $prime);
-				$output->writeln('OPTIMUS_INVERSE=' . $inverse);
-				$output->writeln('OPTIMUS_RANDOM=' . $rand);
-				$output->writeln('OPTIMUS_BITLENGTH=' . $bitLength);
-				break;
-			case 'htaccess':
-				$output->writeln('SetEnv OPTIMUS_PRIME ' . $prime);
-				$output->writeln('SetEnv OPTIMUS_INVERSE ' . $inverse);
-				$output->writeln('SetEnv OPTIMUS_RANDOM ' . $rand);
-				$output->writeln('SetEnv OPTIMUS_BITLENGTH ' . $bitLength);
-				break;
-			default:
-				$output->writeln('Prime: ' . $prime);
-				$output->writeln('Inverse: ' . $inverse);
-				$output->writeln('Random: ' . $rand);
-				$output->writeln('Bit length: ' . $bitLength);
-				$output->writeln('');
-				$output->writeln(
-					sprintf(
-						'    new Optimus(%s, %s, %s, %s);',
-						$prime,
-						$inverse,
-						$rand,
-						$bitLength
-					)
-				);
-				break;
-		}
+        switch ($input->getOption('format')) {
+            case 'env':
+                $output->writeln('OPTIMUS_PRIME=' . $prime);
+                $output->writeln('OPTIMUS_INVERSE=' . $inverse);
+                $output->writeln('OPTIMUS_RANDOM=' . $rand);
+                $output->writeln('OPTIMUS_BITLENGTH=' . $bitLength);
+                break;
+            case 'htaccess':
+                $output->writeln('SetEnv OPTIMUS_PRIME ' . $prime);
+                $output->writeln('SetEnv OPTIMUS_INVERSE ' . $inverse);
+                $output->writeln('SetEnv OPTIMUS_RANDOM ' . $rand);
+                $output->writeln('SetEnv OPTIMUS_BITLENGTH ' . $bitLength);
+                break;
+            default:
+                $output->writeln('Prime: ' . $prime);
+                $output->writeln('Inverse: ' . $inverse);
+                $output->writeln('Random: ' . $rand);
+                $output->writeln('Bit length: ' . $bitLength);
+                $output->writeln('');
+                $output->writeln(
+                    sprintf(
+                        '    new Optimus(%s, %s, %s, %s);',
+                        $prime,
+                        $inverse,
+                        $rand,
+                        $bitLength
+                    )
+                );
+                break;
+        }
     }
 }

--- a/src/Commands/SparkCommand.php
+++ b/src/Commands/SparkCommand.php
@@ -72,6 +72,12 @@ class SparkCommand extends Command
 				$output->writeln('OPTIMUS_RANDOM=' . $rand);
 				$output->writeln('OPTIMUS_BITLENGTH=' . $bitLength);
 				break;
+			case 'htaccess':
+				$output->writeln('SetEnv OPTIMUS_PRIME ' . $prime);
+				$output->writeln('SetEnv OPTIMUS_INVERSE ' . $inverse);
+				$output->writeln('SetEnv OPTIMUS_RANDOM ' . $rand);
+				$output->writeln('SetEnv OPTIMUS_BITLENGTH ' . $bitLength);
+				break;
 			default:
 				$output->writeln('Prime: ' . $prime);
 				$output->writeln('Inverse: ' . $inverse);


### PR DESCRIPTION
Hi!

I've added an option to the command, with which you can specify an output format.
I have supplied two formats for now (env and htaccess setenv).

The idea is to be able to `tee`the output into an env file.
This could be added to a post-install hook in composer.