### PR TITLE
Fix command with symfony/console 5

### DIFF
--- a/src/Commands/SparkCommand.php
+++ b/src/Commands/SparkCommand.php
@@ -95,5 +95,7 @@ class SparkCommand extends Command
                 );
                 break;
         }
+        
+        return 0;
     }
 }


### PR DESCRIPTION
See https://symfony.com/blog/new-in-symfony-4-4-console-improvements#make-it-mandatory-to-return-the-command-exit-status