### PR TITLE
docs: add symfony bundle

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ Laravel Optimus with multiple connections provided by the [cybercog/laravel-opti
 
 An integration with Silex 2 is provided by the [jaam/silex-optimus-provider](https://packagist.org/packages/jaam/silex-optimus-provider) package.
 
+An integration with Symfony is provided by the [ckrack/optimus-bundle](https://packagist.org/packages/ckrack/optimus-bundle).
+
 An integration with Laravel is provided by the [elfsundae/laravel-hashid](https://github.com/ElfSundae/laravel-hashid) package.
 
 A PSR-15 middleware provided by the [icanhazstring/optimus-middleware](https://github.com/icanhazstring/optimus-middleware) package.


### PR DESCRIPTION
Adds `ckrack/optimus-bundle` link to readme.