### PR TITLE
deprecate EOL php versions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [7.4, 8.0]
+        php: [7.4, 8.0, 8.1]
         composer-flag: [prefer-lowest, prefer-stable]
 
     name: php v${{ matrix.php }} - ${{ matrix.composer-flag }}
@@ -31,8 +31,11 @@ jobs:
       - name: Install dependencies
         run: composer update --${{ matrix.composer-flag }} --no-interaction --no-progress
 
-      - name: Execute tests
+      - name: Execute tests and submit coverage
+        env:
+          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           mkdir -p build/logs
           composer test -- --coverage-clover build/logs/clover.xml
-          [ -f build/logs/clover.xml ] && ./vendor/bin/php-coveralls -v || echo 'clover.xml not found.'
+          composer require --dev -n "php-coveralls/php-coveralls":"^2.5.2"
+          ./vendor/bin/php-coveralls -v 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,9 @@ If you will be running your code on a 32 bit system or will be working with larg
 For debian/ubuntu you can install the extension with one of these commands:
 
 ```bash
-apt-get install php7.0-gmp
-apt-get install php7.1-gmp
-apt-get install php7.2-gmp
-apt-get install php7.3-gmp
 apt-get install php7.4-gmp
+apt-get install php8.0-gmp
+apt-get install php8.1-gmp
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,12 @@
         }
     ],
     "require": {
-        "php": ">=7.0.0",
+        "php": "^7.4||^8.0",
         "phpseclib/phpseclib": "^3.0",
-        "symfony/console": "^3.0|^4.0|^5.0"
+        "symfony/console": "^5.0||^6.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^6.0|^7.0|^8.0",
-        "php-coveralls/php-coveralls": "^2.1"
+        "phpunit/phpunit": "^9.5.10"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         backupGlobals="false"
          backupStaticAttributes="false"
          bootstrap="vendor/autoload.php"
          colors="true"
@@ -7,15 +8,16 @@
          convertNoticesToExceptions="true"
          convertWarningsToExceptions="true"
          processIsolation="false"
-         stopOnFailure="false">
+         stopOnFailure="false"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+    <coverage includeUncoveredFiles="false">
+        <include>
+            <directory suffix=".php">src/</directory>
+        </include>
+    </coverage>
     <testsuites>
         <testsuite name="Optimus">
             <directory>./tests/</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="false">
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
 </phpunit>


### PR DESCRIPTION
Hi @jenssegers 

### Highlights
* Remove support for EOL php versions (7.0, 7.1, 7.2, 7.3)
* See package usage stats [here](https://packagist.org/packages/jenssegers/optimus/php-stats)
* Upgrade phpunit to 9.x
* Test on php 8.1 as well
* Remove support for  `symfony/console` v3 and v4
* Allow `symfony/console` v6.x 

Thanks.
