### PR TITLE
Bugfix/php8.3

### DIFF
--- a/src/Commands/SparkCommand.php
+++ b/src/Commands/SparkCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SparkCommand extends Command
 {
-    protected function configure()
+    protected function configure(): int
     {
         $this
             ->setName('spark')
@@ -37,8 +37,7 @@ class SparkCommand extends Command
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
-    {
+    protected function execute(InputInterface $input, OutputInterface $output): int {
         $bitLength = $input->getOption('bits');
 
         $minBitLength = 4;

--- a/src/Commands/SparkCommand.php
+++ b/src/Commands/SparkCommand.php
@@ -35,10 +35,12 @@ class SparkCommand extends Command
                 InputArgument::OPTIONAL,
                 'Your prime number'
             );
+
+        return 1; // method requires an integer return value
     }
 
     protected function execute(InputInterface $input, OutputInterface $output): int
-	{
+    {
         $bitLength = $input->getOption('bits');
 
         $minBitLength = 4;

--- a/src/Commands/SparkCommand.php
+++ b/src/Commands/SparkCommand.php
@@ -13,7 +13,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 class SparkCommand extends Command
 {
-    protected function configure()
+    protected function configure(): int
     {
         $this
             ->setName('spark')
@@ -37,8 +37,8 @@ class SparkCommand extends Command
             );
     }
 
-    protected function execute(InputInterface $input, OutputInterface $output)
-    {
+    protected function execute(InputInterface $input, OutputInterface $output): int
+	{
         $bitLength = $input->getOption('bits');
 
         $minBitLength = 4;


### PR DESCRIPTION
Parent class of SparkCommand.php -> Symfony\Component\Console\Command\Command requires a return type specified.  Added required return type.

The lack of return type was causing issues with php 8.3